### PR TITLE
[FIX] Ignore updating when setting key with same value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "golden-path",
-  "version": "1.1.4-rc2",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "golden-path",
-  "version": "1.1.3",
+  "version": "1.1.4-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "golden-path",
-  "version": "1.1.4-rc",
+  "version": "1.1.4-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "golden-path",
-  "version": "1.1.4-rc",
+  "version": "1.1.4-rc2",
   "description": "Golden Path",
   "keywords": [
     "functional",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "golden-path",
-  "version": "1.1.3",
+  "version": "1.1.4-rc",
   "description": "Golden Path",
   "keywords": [
     "functional",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "golden-path",
-  "version": "1.1.4-rc2",
+  "version": "1.1.4",
   "description": "Golden Path",
   "keywords": [
     "functional",

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,17 @@ const update = curry((unResolvedPath, value, object) => {
             }
 
             const isSameValue = rPath(p, objectResult) === newVal;
-            if (isSameValue) { return; }
+            if (isSameValue) {
+                if (typeof window !== 'undefined') {
+                    if (!window.goldenExcludedUpdates) {
+                        window.goldenExcludedUpdates = [];
+                    }
+            
+                    window.goldenExcludedUpdates.push({ k: p });
+                }
+
+                return;
+            }
         
             objectResult = assocPath(p, newVal, objectResult)
         });

--- a/src/index.js
+++ b/src/index.js
@@ -20,17 +20,7 @@ const update = curry((unResolvedPath, value, object) => {
             }
 
             const isSameValue = rPath(p, objectResult) === newVal;
-            if (isSameValue) {
-                if (typeof window !== 'undefined') {
-                    if (!window.goldenExcludedUpdates) {
-                        window.goldenExcludedUpdates = [];
-                    }
-            
-                    window.goldenExcludedUpdates.push({ k: p });
-                }
-
-                return;
-            }
+            if (isSameValue) { return; }
         
             objectResult = assocPath(p, newVal, objectResult)
         });

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,9 @@ const update = curry((unResolvedPath, value, object) => {
                     rPath(p, object)
                 );
             }
+
+            const isSameValue = rPath(p, objectResult) === newVal;
+            if (isSameValue) { return; }
         
             objectResult = assocPath(p, newVal, objectResult)
         });

--- a/src/update.spec.js
+++ b/src/update.spec.js
@@ -7,6 +7,14 @@ describe('update', () => {
         expect(result).toEqual({ islam: 4 });
     });
 
+    it('should return same reference once key updated with same value', () => {
+        const object = { islam: 1 };
+        const result = update('islam', 1, object);
+
+        // referential equality
+        expect(result).toBe(object);
+    });
+
     it('should update one level path when exist when function is being passed', () => {
         const object = { islam: 1 };
         const result = update('islam', (x) => x + 1, object);


### PR DESCRIPTION
This fix has been done in order to improve `react-wisteria` performance.
This change will not perform the functional update if the leaf has the same value and will return same reference.
**(See added spec - Was failing before this change)**

When we update the Wisteria state we call the updater from `golden-path` which was breaking the path reference in order to update values with their same current values which cause state reference to get changed for react state which forced a re-render.. With this change, the `golden-path` will ignore the update and return same reference which gives React an indication not to re-render!

### React Wisteria updates

![image](https://user-images.githubusercontent.com/7091543/123417269-3edc6380-d5c0-11eb-8246-3140f20b1d70.png)

If the `updater` didn't changed the state and returned it as is then React will ignore the need for re-rendering.

On some of Fiverr's pages that improved JavaScript execution about **~36%**!! 🎉 

## Before

![image](https://user-images.githubusercontent.com/7091543/123418597-e6a66100-d5c1-11eb-9db1-22911471a9f2.png)

## After

![image](https://user-images.githubusercontent.com/7091543/123418554-d8f0db80-d5c1-11eb-92ad-d717967ec994.png)